### PR TITLE
Add `column order` support for index annotations

### DIFF
--- a/src/MergeIndexes.php
+++ b/src/MergeIndexes.php
@@ -18,6 +18,7 @@ use Cycle\Schema\GeneratorInterface;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\AnnotationException as DoctrineException;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Spiral\Database\Schema\AbstractIndex;
 use Spiral\Database\Schema\AbstractTable;
 
 /**
@@ -125,12 +126,17 @@ final class MergeIndexes implements GeneratorInterface
     {
         $result = [];
 
-        foreach ($columns as $column) {
+        foreach ($columns as $expression) {
+            [$column, $order] = AbstractIndex::parseColumn($expression);
+
             if ($entity->getFields()->has($column)) {
-                $result[] = $entity->getFields()->get($column)->getColumn();
+                $mappedName = $entity->getFields()->get($column)->getColumn();
             } else {
-                $result[] = $column;
+                $mappedName = $column;
             }
+
+            // Re-construct `column ORDER` with mapped column name
+            $result[] = $order ? "$mappedName $order" : $mappedName;
         }
 
         return $result;

--- a/tests/Annotated/Driver/MySQL/TableTest.php
+++ b/tests/Annotated/Driver/MySQL/TableTest.php
@@ -14,4 +14,13 @@ namespace Cycle\Annotated\Tests\Driver\MySQL;
 class TableTest extends \Cycle\Annotated\Tests\TableTest
 {
     public const DRIVER = 'mysql';
+
+    public function testOrderedIndexes(): void
+    {
+        if (getenv('DB') === 'mariadb') {
+            $this->expectExceptionMessageRegExp('/column sorting is not supported$/');
+        }
+
+        parent::testOrderedIndexes();
+    }
 }

--- a/tests/Annotated/Fixtures9/OrderedIdx.php
+++ b/tests/Annotated/Fixtures9/OrderedIdx.php
@@ -27,7 +27,7 @@ use Cycle\Annotated\Annotation\Table\Index;
  *      }
  * )
  */
-class WithTableOrderedIndex
+class OrderedIdx
 {
     /** @Column(type="primary") */
     protected $id;

--- a/tests/Annotated/Fixtures9/WithTableOrderedIndex.php
+++ b/tests/Annotated/Fixtures9/WithTableOrderedIndex.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Fixtures9;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\Annotated\Annotation\Table;
+use Cycle\Annotated\Annotation\Table\Index;
+
+/**
+ * @Entity()
+ * @Table(
+ *      columns = {
+ *          "name": @Column(type="string"),
+ *      },
+ *      indexes = {
+ *          @Index(columns={"name", "id DESC"}),
+ *      }
+ * )
+ */
+class WithTableOrderedIndex
+{
+    /** @Column(type="primary") */
+    protected $id;
+}

--- a/tests/Annotated/TableTest.php
+++ b/tests/Annotated/TableTest.php
@@ -81,9 +81,9 @@ abstract class TableTest extends BaseTest
         (new MergeIndexes())->run($r);
         (new SyncTables())->run($r);
 
-        $this->assertTrue($r->hasTable($r->getEntity('withTableOrderedIndex')));
+        $this->assertTrue($r->hasTable($r->getEntity('orderedIdx')));
 
-        $schema = $r->getTableSchema($r->getEntity('withTableOrderedIndex'));
+        $schema = $r->getTableSchema($r->getEntity('orderedIdx'));
 
         $this->assertTrue($schema->hasIndex(['name', 'id DESC']));
     }

--- a/tests/Annotated/TableTest.php
+++ b/tests/Annotated/TableTest.php
@@ -17,6 +17,8 @@ use Cycle\Annotated\MergeIndexes;
 use Cycle\Schema\Generator\RenderTables;
 use Cycle\Schema\Generator\SyncTables;
 use Cycle\Schema\Registry;
+use Spiral\Tokenizer\Config\TokenizerConfig;
+use Spiral\Tokenizer\Tokenizer;
 
 abstract class TableTest extends BaseTest
 {
@@ -60,6 +62,30 @@ abstract class TableTest extends BaseTest
         $this->assertSame('name_index', $schema->index(['name'])->getName());
 
         $this->assertTrue($schema->hasIndex(['status']));
+    }
+
+    public function testOrderedIndexes(): void
+    {
+        $tokenizer = new Tokenizer(new TokenizerConfig([
+            'directories' => [__DIR__ . '/Fixtures9'],
+            'exclude'     => [],
+        ]));
+
+        $locator = $tokenizer->classLocator();
+
+        $r = new Registry($this->dbal);
+
+        (new Entities($locator))->run($r);
+        (new MergeColumns())->run($r);
+        (new RenderTables())->run($r);
+        (new MergeIndexes())->run($r);
+        (new SyncTables())->run($r);
+
+        $this->assertTrue($r->hasTable($r->getEntity('withTableOrderedIndex')));
+
+        $schema = $r->getTableSchema($r->getEntity('withTableOrderedIndex'));
+
+        $this->assertTrue($schema->hasIndex(['name', 'id DESC']));
     }
 
     public function testNamingDefault(): void


### PR DESCRIPTION
This brings in support for ordered indexes in cycle annotations like:

```
@Index(columns={"name", "id DESC"})
```