### PR TITLE
Initial implementation for class table inheritance

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -94,8 +94,7 @@ final class Configurator
         \ReflectionClass $class,
         string $columnPrefix = '',
         $skipInherited = false
-    ): void
-    {
+    ): void {
         foreach ($class->getProperties() as $property) {
             try {
                 /** @var Column $column */

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -103,10 +103,20 @@ final class Configurator
                 continue;
             }
 
-            if ($skipInherited
-                && $property->getDeclaringClass()->getName() !== $entity->getClass()
-                && $column->getType() !== 'primary') {
-                continue;
+            if ($skipInherited && $property->getDeclaringClass()->getName() !== $entity->getClass()) {
+                if ($column->getType() === 'primary' || $column->isPrimary()) {
+                    $relation = new Relation();
+                    $relation->setType('belongsTo');
+                    $relation->setTarget($property->getDeclaringClass()->getName());
+                    $relation->getOptions()->set('innerKey', $property->getName());
+
+                    $entity->getRelations()->set(
+                        $this->inflector->camelize($property->getDeclaringClass()->getShortName()),
+                        $relation
+                    );
+                } else {
+                    continue;
+                }
             }
 
             $entity->getFields()->set(

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -89,7 +89,12 @@ final class Configurator
      * @param string           $columnPrefix
      * @param bool             $skipInherited
      */
-    public function initFields(EntitySchema $entity, \ReflectionClass $class, string $columnPrefix = '', $skipInherited = false): void
+    public function initFields(
+        EntitySchema $entity,
+        \ReflectionClass $class,
+        string $columnPrefix = '',
+        $skipInherited = false
+    ): void
     {
         foreach ($class->getProperties() as $property) {
             try {


### PR DESCRIPTION
See [cycle/orm#116](https://github.com/cycle/orm/issues/116).

This PR ensures that if we annotate child entity with different table than the parent, the child will be built as a separate entity with separate table. The primary key is taken from the parent.

I'm still not sure how to add FK constrain to the child automatically in this case without actually adding annotated @HasOne relation.

For this to fully work we also need a custom mapper for `cycle/orm`.