### PR TITLE
Deprecate `though`, add `through` annotation stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ class User
     /** @HasMany(target=Post::class, load="lazy") */
     protected $posts;
    
-    /** @ManyToMany(target=Tag::class, though=TagMap::class, load="lazy") */
+    /** @ManyToMany(target=Tag::class, through=TagMap::class, load="lazy") */
     protected $tags;
     
     ...

--- a/resources/stubs/Relation/ManyToMany.php
+++ b/resources/stubs/Relation/ManyToMany.php
@@ -10,7 +10,8 @@ final class ManyToMany
 {
     public function __construct(
         string $target,
-        string $though,
+        string $though = null,
+        string $through = null,
         bool $cascade = true,
         bool $nullable = false,
         string $innerKey = null,
@@ -20,6 +21,9 @@ final class ManyToMany
         string $thoughInnerKey = '{sourceRole}_{innerKey}',
         string $thoughOuterKey = '{targetRole}_{outerKey}',
         array $thoughWhere = [],
+        array $throughInnerKey = [],
+        array $throughOuterKey = [],
+        array $throughWhere = [],
         bool $fkCreate = true,
         #[ExpectedValues(values: ['NO ACTION', 'CASCADE', 'SET NULL'])]
         string $fkAction = 'SET NULL',

--- a/src/Annotation/Relation/ManyToMany.php
+++ b/src/Annotation/Relation/ManyToMany.php
@@ -59,16 +59,28 @@ final class ManyToMany extends Relation
     /** @var array */
     protected $orderBy;
 
-    /** @var string @deprecated */
+    /**
+     * @var string
+     * @deprecated
+     */
     protected $though;
 
-    /** @var string @deprecated */
+    /**
+     * @var string
+     * @deprecated
+     */
     protected $thoughInnerKey;
 
-    /** @var string @deprecated */
+    /**
+     * @var string
+     * @deprecated
+     */
     protected $thoughOuterKey;
 
-    /** @var array @deprecated */
+    /**
+     * @var array
+     * @deprecated
+     */
     protected $thoughWhere;
 
     /** @var string */

--- a/src/Annotation/Relation/ManyToMany.php
+++ b/src/Annotation/Relation/ManyToMany.php
@@ -20,10 +20,14 @@ use Doctrine\Common\Annotations\Annotation\Enum;
  *      @Attribute("outerKey", type="string"),
  *      @Attribute("where", type="array"),
  *      @Attribute("orderBy", type="array"),
- *      @Attribute("though", type="string", required=true),
+ *      @Attribute("though", type="string"),
  *      @Attribute("thoughInnerKey", type="string"),
  *      @Attribute("thoughOuterKey", type="string"),
  *      @Attribute("thoughWhere", type="array"),
+ *      @Attribute("through", type="string"),
+ *      @Attribute("throughInnerKey", type="array<string>"),
+ *      @Attribute("throughOuterKey", type="array<string>"),
+ *      @Attribute("throughWhere", type="array"),
  *      @Attribute("fkCreate", type="bool"),
  *      @Attribute("fkAction", type="string"),
  *      @Attribute("indexCreate", type="bool"),
@@ -55,17 +59,29 @@ final class ManyToMany extends Relation
     /** @var array */
     protected $orderBy;
 
-    /** @var string */
+    /** @var string @deprecated */
     protected $though;
 
-    /** @var string */
+    /** @var string @deprecated */
     protected $thoughInnerKey;
 
-    /** @var string */
+    /** @var string @deprecated */
     protected $thoughOuterKey;
 
-    /** @var array */
+    /** @var array @deprecated */
     protected $thoughWhere;
+
+    /** @var string */
+    protected $through;
+
+    /** @var array */
+    protected $throughInnerKey;
+
+    /** @var array */
+    protected $throughOuterKey;
+
+    /** @var array */
+    protected $throughWhere;
 
     /** @var bool */
     protected $fkCreate;

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -146,7 +146,7 @@ final class Configurator
                 }
 
                 foreach ($meta->getOptions() as $option => $value) {
-                    if ($option === 'though') {
+                    if ($option === 'though' || $option === 'through') {
                         $value = $this->resolveName($value, $class);
                     }
 

--- a/src/Entities.php
+++ b/src/Entities.php
@@ -132,10 +132,23 @@ final class Entities implements GeneratorInterface
                     $r->setTarget($this->resolveTarget($registry, $r->getTarget()));
 
                     if ($r->getOptions()->has('though')) {
-                        $r->getOptions()->set(
-                            'though',
-                            $this->resolveTarget($registry, $r->getOptions()->get('though'))
-                        );
+                        $though = $r->getOptions()->get('though');
+                        if ($though !== null) {
+                            $r->getOptions()->set(
+                                'though',
+                                $this->resolveTarget($registry, $though)
+                            );
+                        }
+                    }
+
+                    if ($r->getOptions()->has('through')) {
+                        $through = $r->getOptions()->get('through');
+                        if ($through !== null) {
+                            $r->getOptions()->set(
+                                'through',
+                                $this->resolveTarget($registry, $through)
+                            );
+                        }
                     }
                 } catch (RegistryException $ex) {
                     throw new RelationException(

--- a/src/Entities.php
+++ b/src/Entities.php
@@ -151,42 +151,14 @@ final class Entities implements GeneratorInterface
                         }
                     }
 
-                    /**
-                     * We wanted to include composite keys support because it would be harder
-                     * to change the annotation signature later, but cycle itself doesn't support
-                     * composite keys on the ORM schema level, so we include a temporary hack
-                     * that limits the THROUGH inner and outer keys to a single element array.
-                     *
-                     * @see https://github.com/cycle/schema-builder/issues/25
-                     */
                     if ($r->getOptions()->has('throughInnerKey')) {
                         if ($throughInnerKey = (array)$r->getOptions()->get('throughInnerKey')) {
-                            if (count($throughInnerKey) > 1) {
-                                throw new AnnotationException(
-                                    sprintf(
-                                        'Invalid `%s`.`%s` relation, composite `throughInnerKey`s are not supported for ManyToMany yet',
-                                        $e->getRole(),
-                                        $name
-                                    )
-                                );
-                            }
-
                             $r->getOptions()->set('throughInnerKey', $throughInnerKey[0]);
                         }
                     }
 
                     if ($r->getOptions()->has('throughOuterKey')) {
                         if ($throughOuterKey = (array)$r->getOptions()->get('throughOuterKey')) {
-                            if (count($throughOuterKey) > 1) {
-                                throw new AnnotationException(
-                                    sprintf(
-                                        'Invalid `%s`.`%s` relation, composite `throughOuterKey`s are not supported for ManyToMany yet',
-                                        $e->getRole(),
-                                        $name
-                                    )
-                                );
-                            }
-
                             $r->getOptions()->set('throughOuterKey', $throughOuterKey[0]);
                         }
                     }

--- a/src/Entities.php
+++ b/src/Entities.php
@@ -150,6 +150,46 @@ final class Entities implements GeneratorInterface
                             );
                         }
                     }
+
+                    /**
+                     * We wanted to include composite keys support because it would be harder
+                     * to change the annotation signature later, but cycle itself doesn't support
+                     * composite keys on the ORM schema level, so we include a temporary hack
+                     * that limits the THROUGH inner and outer keys to a single element array.
+                     *
+                     * @see https://github.com/cycle/schema-builder/issues/25
+                     */
+                    if ($r->getOptions()->has('throughInnerKey')) {
+                        if ($throughInnerKey = (array)$r->getOptions()->get('throughInnerKey')) {
+                            if (count($throughInnerKey) > 1) {
+                                throw new AnnotationException(
+                                    sprintf(
+                                        'Invalid `%s`.`%s` relation, composite `throughInnerKey`s are not supported for ManyToMany yet',
+                                        $e->getRole(),
+                                        $name
+                                    )
+                                );
+                            }
+
+                            $r->getOptions()->set('throughInnerKey', $throughInnerKey[0]);
+                        }
+                    }
+
+                    if ($r->getOptions()->has('throughOuterKey')) {
+                        if ($throughOuterKey = (array)$r->getOptions()->get('throughOuterKey')) {
+                            if (count($throughOuterKey) > 1) {
+                                throw new AnnotationException(
+                                    sprintf(
+                                        'Invalid `%s`.`%s` relation, composite `throughOuterKey`s are not supported for ManyToMany yet',
+                                        $e->getRole(),
+                                        $name
+                                    )
+                                );
+                            }
+
+                            $r->getOptions()->set('throughOuterKey', $throughOuterKey[0]);
+                        }
+                    }
                 } catch (RegistryException $ex) {
                     throw new RelationException(
                         sprintf(

--- a/tests/Annotated/Fixtures/ThroughThough.php
+++ b/tests/Annotated/Fixtures/ThroughThough.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Fixtures;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\Annotated\Annotation\Relation\ManyToMany;
+
+/**
+ * @Entity()
+ * @Column(name="name", type="string"),
+ */
+#[Entity]
+#[Column(name: 'name', type: 'string')]
+class ThroughThough
+{
+    /** @Column(type="primary") */
+    #[Column(type: "primary")]
+    protected $id;
+
+    /** @ManyToMany(target="Tag", through="Label", though="Tag\Context", throughInnerKey={"withTable_id"}, throughOuterKey="tag_id") */
+    #[ManyToMany(target: "Tag", through: "Label", though: "Tag\Context", throughInnerKey: "withTable_id", throughOuterKey: ["tag_id"])]
+    protected $tags;
+}

--- a/tests/Annotated/Fixtures/WithTable.php
+++ b/tests/Annotated/Fixtures/WithTable.php
@@ -31,8 +31,8 @@ class WithTable implements LabelledInterface
     #[Column(type: "primary")]
     protected $id;
 
-    /** @ManyToMany(target="Tag", though="Tag/Context", where={"id": {">=": "1"}}, orderBy={"id": "DESC"}) */
-    #[ManyToMany(target: "Tag", though: "Tag/Context", where: ["id" => [">=" => "1"]], orderBy: ["id" => "DESC"])]
+    /** @ManyToMany(target="Tag", through="Tag/Context", where={"id": {">=": "1"}}, orderBy={"id": "DESC"}) */
+    #[ManyToMany(target: "Tag", through: "Tag/Context", where: ["id" => [">=" => "1"]], orderBy: ["id" => "DESC"])]
     protected $tags;
 
     /** @MorphedHasMany(target="Label", outerKey="owner_id", morphKey="owner_role", indexCreate=false) */

--- a/tests/Annotated/Fixtures/WithTable2.php
+++ b/tests/Annotated/Fixtures/WithTable2.php
@@ -17,22 +17,22 @@ use Cycle\Annotated\Annotation\Table\Index;
  * @Column(name="status", type="enum(active,disabled)", default="active", property="status_property")
  * @Column(property="no_column_name", type="string", default="")
  * @Index(columns={"status"}),
- * @Index(columns={"name"}, unique=true, name="name_index")
+ * @Index(columns={"name"}, unique=true, name="name_index2")
  */
 #[Entity]
 #[Column(name: 'name', type: 'string')]
 #[Column(name: 'status', property: 'status_property', type: 'enum(active,disabled)', default: 'active')]
 #[Column(property: 'no_column_name', type: 'string', default: '')]
 #[Index(columns: ["status"])]
-#[Index(name: "name_index", columns: ["name"], unique: true)]
-class WithTable implements LabelledInterface
+#[Index(name: "name_index2", columns: ["name"], unique: true)]
+class WithTable2 implements LabelledInterface
 {
     /** @Column(type="primary") */
     #[Column(type: "primary")]
     protected $id;
 
-    /** @ManyToMany(target="Tag", through="Tag/Context", throughInnerKey={"withTable_id"}, throughOuterKey="tag_id", where={"id": {">=": "1"}}, orderBy={"id": "DESC"}) */
-    #[ManyToMany(target: "Tag", through: "Tag/Context", throughInnerKey: "withTable_id", throughOuterKey: ["tag_id"], where: ["id" => [">=" => "1"]], orderBy: ["id" => "DESC"])]
+    /** @ManyToMany(target="Tag", though="Tag/Context", thoughInnerKey="withTable2_id", thoughOuterKey="tag_id", where={"id": {">=": "1"}}, orderBy={"id": "DESC"}) */
+    #[ManyToMany(target: "Tag", though: "Tag/Context", thoughInnerKey: "withTable2_id", thoughOuterKey: "tag_id", where: ["id" => [">=" => "1"]], orderBy: ["id" => "DESC"])]
     protected $tags;
 
     /** @MorphedHasMany(target="Label", outerKey="owner_id", morphKey="owner_role", indexCreate=false) */

--- a/tests/Annotated/Relation/ManyToManyTest.php
+++ b/tests/Annotated/Relation/ManyToManyTest.php
@@ -59,12 +59,78 @@ abstract class ManyToManyTest extends BaseTest
         );
 
         $this->assertSame(
+            'withTable_id',
+            $schema['withTable'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::THROUGH_INNER_KEY]
+        );
+
+        $this->assertSame(
+            'tag_id',
+            $schema['withTable'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::THROUGH_OUTER_KEY]
+        );
+
+        $this->assertSame(
             ["id" => [">=" => "1"]],
             $schema['withTable'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::WHERE]
         );
         $this->assertSame(
             ["id" => "DESC"],
             $schema['withTable'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::ORDER_BY]
+        );
+    }
+
+    /**
+     * @dataProvider allReadersProvider
+     */
+    public function testThoughRelation(ReaderInterface $reader): void
+    {
+        $r = new Registry($this->dbal);
+
+        $schema = (new Compiler())->compile($r, [
+            new Entities($this->locator, $reader),
+            new ResetTables(),
+            new MergeColumns($reader),
+            new GenerateRelations(),
+            new RenderTables(),
+            new RenderRelations(),
+            new MergeIndexes($reader),
+            new SyncTables(),
+            new GenerateTypecast(),
+        ]);
+
+        $this->assertArrayHasKey('tags', $schema['withTable2'][Schema::RELATIONS]);
+
+        $this->assertSame(
+            Relation::MANY_TO_MANY,
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::TYPE]
+        );
+
+        $this->assertSame(
+            'tag',
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::TARGET]
+        );
+
+        $this->assertSame(
+            'tagContext',
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::THROUGH_ENTITY]
+        );
+
+        $this->assertSame(
+            'withTable2_id',
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::THROUGH_INNER_KEY]
+        );
+
+        $this->assertSame(
+            'tag_id',
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::THROUGH_OUTER_KEY]
+        );
+
+        $this->assertSame(
+            ["id" => [">=" => "1"]],
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::WHERE]
+        );
+        $this->assertSame(
+            ["id" => "DESC"],
+            $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::ORDER_BY]
         );
     }
 }

--- a/tests/Annotated/Relation/ManyToManyTest.php
+++ b/tests/Annotated/Relation/ManyToManyTest.php
@@ -132,5 +132,10 @@ abstract class ManyToManyTest extends BaseTest
             ["id" => "DESC"],
             $schema['withTable2'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::ORDER_BY]
         );
+
+        $this->assertSame(
+            'label',
+            $schema['throughThough'][Schema::RELATIONS]['tags'][Relation::SCHEMA][Relation::THROUGH_ENTITY]
+        );
     }
 }


### PR DESCRIPTION
I had to drop required constraint on `though`, otherwise I couldn't find a way to make this a smooth transition.
Upon removal of `though` after one cycle (pun intended), we can switch the required constraint back on for `through`.

Closes #10.

Cc: @roxblnfk 