### PR TITLE
Adding the ability to use Locators

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="tests/bootstrap.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -9,16 +10,15 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         stopOnError="false">
-    <testsuites>
-        <testsuite name="Cycle ORM Annotated Entities">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+         stopOnError="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Cycle ORM Annotated Entities">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Entities.php
+++ b/src/Entities.php
@@ -32,9 +32,9 @@ final class Entities implements GeneratorInterface
         DoctrineReader|ReaderInterface $reader = null,
         int $tableNamingStrategy = self::TABLE_NAMING_PLURAL
     ) {
-        $this->reader = ReaderFactory::create($reader);
-        $this->utils = new EntityUtils($this->reader);
-        $this->generator = new Configurator($this->reader, $tableNamingStrategy);
+        $reader = ReaderFactory::create($reader);
+        $this->utils = new EntityUtils($reader);
+        $this->generator = new Configurator($reader, $tableNamingStrategy);
     }
 
     public function run(Registry $registry): Registry

--- a/src/Locator/Embedding.php
+++ b/src/Locator/Embedding.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Locator;
+
+use Cycle\Annotated\Annotation\Embeddable;
+
+final class Embedding
+{
+    public function __construct(
+        public Embeddable $attribute,
+        public \ReflectionClass $class
+    ) {
+    }
+}

--- a/src/Locator/EmbeddingLocatorInterface.php
+++ b/src/Locator/EmbeddingLocatorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Locator;
+
+interface EmbeddingLocatorInterface
+{
+    /**
+     * @return Embedding[]
+     */
+    public function getEmbeddings(): array;
+}

--- a/src/Locator/Entity.php
+++ b/src/Locator/Entity.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Locator;
+
+use Cycle\Annotated\Annotation\Entity as Attribute;
+
+final class Entity
+{
+    public function __construct(
+        public Attribute $attribute,
+        public \ReflectionClass $class
+    ) {
+    }
+}

--- a/src/Locator/EntityLocatorInterface.php
+++ b/src/Locator/EntityLocatorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Locator;
+
+interface EntityLocatorInterface
+{
+    /**
+     * @return Entity[]
+     */
+    public function getEntities(): array;
+}

--- a/src/Locator/TokenizerEmbeddingLocator.php
+++ b/src/Locator/TokenizerEmbeddingLocator.php
@@ -20,7 +20,7 @@ final class TokenizerEmbeddingLocator implements EmbeddingLocatorInterface
     private ReaderInterface $reader;
 
     public function __construct(
-        private ClassesInterface $locator,
+        private ClassesInterface $classes,
         DoctrineReader|ReaderInterface $reader = null,
     ) {
         $this->reader = ReaderFactory::create($reader);
@@ -28,7 +28,9 @@ final class TokenizerEmbeddingLocator implements EmbeddingLocatorInterface
 
     public function getEmbeddings(): array
     {
-        foreach ($this->locator->getClasses() as $class) {
+        $this->embeddings = [];
+
+        foreach ($this->classes->getClasses() as $class) {
             try {
                 $attribute = $this->reader->firstClassMetadata($class, Embeddable::class);
             } catch (\Exception $e) {

--- a/src/Locator/TokenizerEmbeddingLocator.php
+++ b/src/Locator/TokenizerEmbeddingLocator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Locator;
+
+use Cycle\Annotated\Annotation\Embeddable;
+use Cycle\Annotated\Exception\AnnotationException;
+use Cycle\Annotated\ReaderFactory;
+use Doctrine\Common\Annotations\Reader as DoctrineReader;
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Tokenizer\ClassesInterface;
+
+final class TokenizerEmbeddingLocator implements EmbeddingLocatorInterface
+{
+    /**
+     * @var Embedding[]
+     */
+    private array $embeddings = [];
+    private ReaderInterface $reader;
+
+    public function __construct(
+        private ClassesInterface $locator,
+        DoctrineReader|ReaderInterface $reader = null,
+    ) {
+        $this->reader = ReaderFactory::create($reader);
+    }
+
+    public function getEmbeddings(): array
+    {
+        foreach ($this->locator->getClasses() as $class) {
+            try {
+                $attribute = $this->reader->firstClassMetadata($class, Embeddable::class);
+            } catch (\Exception $e) {
+                throw new AnnotationException($e->getMessage(), $e->getCode(), $e);
+            }
+
+            if ($attribute !== null) {
+                $this->embeddings[] = new Embedding($attribute, $class);
+            }
+        }
+
+        return $this->embeddings;
+    }
+}

--- a/src/Locator/TokenizerEntityLocator.php
+++ b/src/Locator/TokenizerEntityLocator.php
@@ -20,7 +20,7 @@ final class TokenizerEntityLocator implements EntityLocatorInterface
     private ReaderInterface $reader;
 
     public function __construct(
-        private ClassesInterface $locator,
+        private ClassesInterface $classes,
         DoctrineReader|ReaderInterface $reader = null,
     ) {
         $this->reader = ReaderFactory::create($reader);
@@ -28,7 +28,9 @@ final class TokenizerEntityLocator implements EntityLocatorInterface
 
     public function getEntities(): array
     {
-        foreach ($this->locator->getClasses() as $class) {
+        $this->entities = [];
+
+        foreach ($this->classes->getClasses() as $class) {
             try {
                 /** @var Attribute $attribute */
                 $attribute = $this->reader->firstClassMetadata($class, Attribute::class);

--- a/src/Locator/TokenizerEntityLocator.php
+++ b/src/Locator/TokenizerEntityLocator.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Locator;
+
+use Cycle\Annotated\Annotation\Entity as Attribute;
+use Cycle\Annotated\Exception\AnnotationException;
+use Cycle\Annotated\ReaderFactory;
+use Doctrine\Common\Annotations\Reader as DoctrineReader;
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Tokenizer\ClassesInterface;
+
+final class TokenizerEntityLocator implements EntityLocatorInterface
+{
+    /**
+     * @var Entity[]
+     */
+    private array $entities = [];
+    private ReaderInterface $reader;
+
+    public function __construct(
+        private ClassesInterface $locator,
+        DoctrineReader|ReaderInterface $reader = null,
+    ) {
+        $this->reader = ReaderFactory::create($reader);
+    }
+
+    public function getEntities(): array
+    {
+        foreach ($this->locator->getClasses() as $class) {
+            try {
+                /** @var Attribute $attribute */
+                $attribute = $this->reader->firstClassMetadata($class, Attribute::class);
+            } catch (\Exception $e) {
+                throw new AnnotationException($e->getMessage(), $e->getCode(), $e);
+            }
+
+            if ($attribute !== null) {
+                $this->entities[] = new Entity($attribute, $class);
+            }
+        }
+
+        return $this->entities;
+    }
+}

--- a/src/Locator/TokenizerEntityLocator.php
+++ b/src/Locator/TokenizerEntityLocator.php
@@ -13,10 +13,6 @@ use Spiral\Tokenizer\ClassesInterface;
 
 final class TokenizerEntityLocator implements EntityLocatorInterface
 {
-    /**
-     * @var Entity[]
-     */
-    private array $entities = [];
     private ReaderInterface $reader;
 
     public function __construct(
@@ -28,8 +24,7 @@ final class TokenizerEntityLocator implements EntityLocatorInterface
 
     public function getEntities(): array
     {
-        $this->entities = [];
-
+        $entities = [];
         foreach ($this->classes->getClasses() as $class) {
             try {
                 /** @var Attribute $attribute */
@@ -39,10 +34,10 @@ final class TokenizerEntityLocator implements EntityLocatorInterface
             }
 
             if ($attribute !== null) {
-                $this->entities[] = new Entity($attribute, $class);
+                $entities[] = new Entity($attribute, $class);
             }
         }
 
-        return $this->entities;
+        return $entities;
     }
 }

--- a/tests/Annotated/Functional/Driver/Common/ChildTest.php
+++ b/tests/Annotated/Functional/Driver/Common/ChildTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Child;
@@ -64,8 +66,8 @@ abstract class ChildTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/GeneratorTest.php
+++ b/tests/Annotated/Functional/Driver/Common/GeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Complete;
@@ -30,7 +31,7 @@ abstract class GeneratorTest extends BaseTest
     public function testCreateEntitiesWithNullReader(): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator)))->run($r);
 
         $this->assertTrue($r->hasEntity(Simple::class));
         $this->assertTrue($r->hasEntity(WithTable::class));
@@ -42,7 +43,7 @@ abstract class GeneratorTest extends BaseTest
         $reader = new DoctrineAnnotationReader();
         $r = new Registry($this->dbal);
 
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
         (new MergeIndexes($reader))->run($r);
@@ -73,7 +74,7 @@ abstract class GeneratorTest extends BaseTest
         ]));
         $locator = $tokenizer->classLocator();
 
-        (new Entities($locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
         (new MergeIndexes($reader))->run($r);
@@ -92,7 +93,7 @@ abstract class GeneratorTest extends BaseTest
     public function testLocateAll(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
 
         $this->assertTrue($r->hasEntity(Simple::class));
         $this->assertTrue($r->hasEntity(WithTable::class));
@@ -105,7 +106,7 @@ abstract class GeneratorTest extends BaseTest
     public function testSimpleSchema(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
 
         $this->assertTrue($r->hasEntity(Simple::class));
         $this->assertTrue($r->hasEntity('simple'));
@@ -127,7 +128,7 @@ abstract class GeneratorTest extends BaseTest
     public function testCompleteSchema(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
 
         $this->assertTrue($r->hasEntity(Complete::class));
         $this->assertTrue($r->hasEntity('eComplete'));

--- a/tests/Annotated/Functional/Driver/Common/Inheritance/JoinedTableTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Inheritance/JoinedTableTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common\Inheritance;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\TableInheritance;
@@ -205,8 +207,8 @@ abstract class JoinedTableTest extends BaseTest
 
         return (new Compiler())->compile(new Registry($this->dbal), [
             new ResetTables(),
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new TableInheritance($reader),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Inheritance/SingleTableTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Inheritance/SingleTableTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common\Inheritance;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\TableInheritance;
@@ -16,7 +18,7 @@ use Cycle\Annotated\Tests\Fixtures\Fixtures16\Ceo;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\Annotated\Tests\Traits\TableTrait;
 use Cycle\ORM\Schema;
-use Cycle\ORM\Transaction;
+use Cycle\ORM\EntityManager;
 use Cycle\Schema\Compiler;
 use Cycle\Schema\Generator\GenerateRelations;
 use Cycle\Schema\Generator\GenerateTypecast;
@@ -65,8 +67,8 @@ abstract class SingleTableTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new TableInheritance($reader),
             new ResetTables(),
             new MergeColumns($reader),
@@ -80,7 +82,7 @@ abstract class SingleTableTest extends BaseTest
 
         $this->orm = $this->orm->with(new Schema($schema));
 
-        $t = new Transaction($this->orm);
+        $t = new EntityManager($this->orm);
 
         $employee = new Employee();
         $employee->name = 'foo';

--- a/tests/Annotated/Functional/Driver/Common/InheritanceTest.php
+++ b/tests/Annotated/Functional/Driver/Common/InheritanceTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\TableInheritance;
@@ -44,8 +46,8 @@ abstract class InheritanceTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new TableInheritance($reader),
             new ResetTables(),
             new MergeColumns($reader),

--- a/tests/Annotated/Functional/Driver/Common/InvalidTest.php
+++ b/tests/Annotated/Functional/Driver/Common/InvalidTest.php
@@ -6,6 +6,7 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Entities;
 use Cycle\Annotated\Exception\AnnotationException;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Schema\Compiler;
@@ -41,7 +42,7 @@ abstract class InvalidTest extends BaseTest
         $this->expectException(RelationException::class);
 
         (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -74,7 +75,7 @@ abstract class InvalidTest extends BaseTest
         $r = new Registry($this->dbal);
 
         (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/BelongsToTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/BelongsToTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -30,7 +31,7 @@ abstract class BelongsToTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/CompositeKeysTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/CompositeKeysTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -38,8 +40,8 @@ abstract class CompositeKeysTest extends BaseTest
         $r = new Registry($this->dbal);
 
         (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/EmbeddedTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/EmbeddedTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -40,8 +42,8 @@ abstract class EmbeddedTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -74,8 +76,8 @@ abstract class EmbeddedTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -108,8 +110,8 @@ abstract class EmbeddedTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/HasManyTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/HasManyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -36,7 +37,7 @@ abstract class HasManyTest extends BaseTest
         $schema = (new Compiler())->compile(
             $r,
             [
-                new Entities($this->locator, $reader),
+                new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
                 new ResetTables(),
                 new MergeColumns($reader),
                 new GenerateRelations(),
@@ -78,7 +79,7 @@ abstract class HasManyTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new MergeColumns($reader),
             new GenerateRelations(),
             $t = new RenderTables(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/HasOneTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/HasOneTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -33,7 +34,7 @@ abstract class HasOneTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -65,7 +66,7 @@ abstract class HasOneTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new MergeColumns($reader),
             new GenerateRelations(),
             $t = new RenderTables(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/InverseTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/InverseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures2\MarkedInterface;
@@ -41,7 +42,7 @@ abstract class InverseTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -77,7 +78,7 @@ abstract class InverseTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -113,7 +114,7 @@ abstract class InverseTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -149,7 +150,7 @@ abstract class InverseTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -189,7 +190,7 @@ abstract class InverseTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/ManyToManyTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/ManyToManyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Collection\BaseCollection;
@@ -46,7 +47,7 @@ abstract class ManyToManyTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new MergeColumns($reader),
             new GenerateRelations(),
             $t = new RenderTables(),
@@ -84,7 +85,7 @@ abstract class ManyToManyTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -144,7 +145,7 @@ abstract class ManyToManyTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),
@@ -212,7 +213,7 @@ abstract class ManyToManyTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new MergeColumns($reader),
             new GenerateRelations(),
             $t = new RenderTables(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/Morphed/BelongsToMorphedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation\Morphed;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Constrain\SomeConstrain;
@@ -32,7 +33,7 @@ abstract class BelongsToMorphedTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/Morphed/MorphedHasManyTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/Morphed/MorphedHasManyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation\Morphed;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Collection\BaseCollection;
@@ -31,7 +32,7 @@ abstract class MorphedHasManyTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/Morphed/MorphedHasOneTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/Morphed/MorphedHasOneTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation\Morphed;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -30,7 +31,7 @@ abstract class MorphedHasOneTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/Relation/RefersToTest.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/RefersToTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common\Relation;
 
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTest;
@@ -30,7 +31,7 @@ abstract class RefersToTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/SchemaModifiersTest.php
+++ b/tests/Annotated/Functional/Driver/Common/SchemaModifiersTest.php
@@ -6,6 +6,8 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Embeddings;
 use Cycle\Annotated\Entities;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Child;
@@ -43,8 +45,8 @@ abstract class SchemaModifiersTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Functional/Driver/Common/TableTest.php
+++ b/tests/Annotated/Functional/Driver/Common/TableTest.php
@@ -250,8 +250,8 @@ abstract class TableTest extends BaseTest
         (new Entities(
             new TokenizerEntityLocator($this->locator, $reader),
             $reader,
-            Entities::TABLE_NAMING_PLURAL)
-        )->run($r);
+            Entities::TABLE_NAMING_PLURAL
+        ))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 
@@ -271,8 +271,8 @@ abstract class TableTest extends BaseTest
         (new Entities(
             new TokenizerEntityLocator($this->locator, $reader),
             $reader,
-            Entities::TABLE_NAMING_SINGULAR)
-        )->run($r);
+            Entities::TABLE_NAMING_SINGULAR
+        ))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 
@@ -292,8 +292,8 @@ abstract class TableTest extends BaseTest
         (new Entities(
             new TokenizerEntityLocator($this->locator, $reader),
             $reader,
-            Entities::TABLE_NAMING_NONE)
-        )->run($r);
+            Entities::TABLE_NAMING_NONE
+        ))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 

--- a/tests/Annotated/Functional/Driver/Common/TableTest.php
+++ b/tests/Annotated/Functional/Driver/Common/TableTest.php
@@ -6,6 +6,7 @@ namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Entities;
 use Cycle\Annotated\Exception\AnnotationException;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\ORM\Schema;
@@ -26,7 +27,7 @@ abstract class TableTest extends BaseTest
     public function testColumnsRendered(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 
@@ -53,7 +54,7 @@ abstract class TableTest extends BaseTest
         $schema = (new Compiler())->compile(
             $r,
             [
-                new Entities($this->locator, $reader),
+                new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
                 new MergeColumns($reader),
                 new RenderTables(),
             ]
@@ -72,7 +73,7 @@ abstract class TableTest extends BaseTest
         $schema = (new Compiler())->compile(
             $r,
             [
-                new Entities($this->locator, $reader),
+                new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
                 new MergeColumns($reader),
                 new RenderTables(),
             ]
@@ -92,7 +93,7 @@ abstract class TableTest extends BaseTest
         $locator = $tokenizer->classLocator();
         $r = new Registry($this->dbal);
         $schema = (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new MergeColumns($reader),
             new RenderTables(),
         ]);
@@ -119,7 +120,7 @@ abstract class TableTest extends BaseTest
         );
 
         (new Compiler())->compile($r, [
-            new Entities($locator, $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new MergeColumns($reader),
             new RenderTables(),
         ]);
@@ -138,7 +139,7 @@ abstract class TableTest extends BaseTest
         ]));
         $locator = $tokenizer->classLocator();
 
-        (new Entities($locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
         (new MergeIndexes($reader))->run($r);
@@ -165,7 +166,7 @@ abstract class TableTest extends BaseTest
         ]));
         $locator = $tokenizer->classLocator();
 
-        (new Entities($locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
         (new MergeIndexes($reader))->run($r);
@@ -178,7 +179,7 @@ abstract class TableTest extends BaseTest
     {
         $r = new Registry($this->dbal);
 
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
         (new MergeIndexes($reader))->run($r);
@@ -209,7 +210,7 @@ abstract class TableTest extends BaseTest
 
         $r = new Registry($this->dbal);
 
-        (new Entities($locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
         (new MergeIndexes($reader))->run($r);
@@ -229,7 +230,7 @@ abstract class TableTest extends BaseTest
     public function testNamingDefault(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader))->run($r);
+        (new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader))->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 
@@ -246,7 +247,11 @@ abstract class TableTest extends BaseTest
     public function testNamingPluralize(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader, Entities::TABLE_NAMING_PLURAL))->run($r);
+        (new Entities(
+            new TokenizerEntityLocator($this->locator, $reader),
+            $reader,
+            Entities::TABLE_NAMING_PLURAL)
+        )->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 
@@ -263,7 +268,11 @@ abstract class TableTest extends BaseTest
     public function testNamingSingular(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader, Entities::TABLE_NAMING_SINGULAR))->run($r);
+        (new Entities(
+            new TokenizerEntityLocator($this->locator, $reader),
+            $reader,
+            Entities::TABLE_NAMING_SINGULAR)
+        )->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 
@@ -280,7 +289,11 @@ abstract class TableTest extends BaseTest
     public function testNamingNone(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
-        (new Entities($this->locator, $reader, Entities::TABLE_NAMING_NONE))->run($r);
+        (new Entities(
+            new TokenizerEntityLocator($this->locator, $reader),
+            $reader,
+            Entities::TABLE_NAMING_NONE)
+        )->run($r);
         (new MergeColumns($reader))->run($r);
         (new RenderTables())->run($r);
 

--- a/tests/Annotated/Functional/Driver/Common/TypecastTest.php
+++ b/tests/Annotated/Functional/Driver/Common/TypecastTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Cycle\Annotated\Tests\Functional\Driver\Common;
 
 use Cycle\Annotated\Embeddings;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeIndexes;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Typecast\Typecaster;
 use Cycle\Annotated\Tests\Fixtures\Fixtures1\Typecast\UuidTypecaster;
@@ -36,7 +38,7 @@ abstract class TypecastTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new MergeColumns($reader),
         ]);
 
@@ -54,7 +56,7 @@ abstract class TypecastTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Entities($this->locator, $reader),
+            new Entities(new TokenizerEntityLocator($this->locator, $reader), $reader),
             new MergeColumns($reader),
         ]);
 
@@ -84,8 +86,8 @@ abstract class TypecastTest extends BaseTest
         $r = new Registry($this->dbal);
 
         $schema = (new Compiler())->compile($r, [
-            new Embeddings($locator, $reader),
-            new Entities($locator, $reader),
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
             new ResetTables(),
             new MergeColumns($reader),
             new GenerateRelations(),

--- a/tests/Annotated/Unit/Locator/TokenizerEmbeddingLocatorTest.php
+++ b/tests/Annotated/Unit/Locator/TokenizerEmbeddingLocatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Unit\Locator;
+
+use Cycle\Annotated\Annotation\Embeddable;
+use Cycle\Annotated\Locator\Embedding;
+use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
+use Cycle\Annotated\Tests\Fixtures\Fixtures1\Child;
+use Cycle\Annotated\Tests\Fixtures\Fixtures7\Address;
+use PHPUnit\Framework\TestCase;
+use Spiral\Tokenizer\ClassesInterface;
+
+final class TokenizerEmbeddingLocatorTest extends TestCase
+{
+    /**
+     * @dataProvider classesDataProvider
+     */
+    public function testGetEmbeddings(array $expected, ClassesInterface $classes): void
+    {
+        $locator = new TokenizerEmbeddingLocator($classes);
+
+        $this->assertEquals($expected, $locator->getEmbeddings());
+    }
+
+    public function classesDataProvider(): \Traversable
+    {
+        $mock = $this->createMock(ClassesInterface::class);
+        $mock->method('getClasses')->willReturn([]);
+        yield [[], $mock];
+
+        $mock = $this->createMock(ClassesInterface::class);
+        $mock->method('getClasses')->willReturn([Child::class => new \ReflectionClass(Child::class)]);
+        yield [[], $mock];
+
+        $mock = $this->createMock(ClassesInterface::class);
+        $mock->method('getClasses')->willReturn([
+            Address::class => new \ReflectionClass(Address::class),
+            Child::class => new \ReflectionClass(Child::class),
+        ]);
+        yield [
+            [
+                new Embedding(
+                    new Embeddable(role: 'address', columnPrefix: 'address_'),
+                    new \ReflectionClass(Address::class)
+                ),
+            ],
+            $mock
+        ];
+    }
+}

--- a/tests/Annotated/Unit/Locator/TokenizerEmbeddingLocatorTest.php
+++ b/tests/Annotated/Unit/Locator/TokenizerEmbeddingLocatorTest.php
@@ -46,7 +46,7 @@ final class TokenizerEmbeddingLocatorTest extends TestCase
                     new \ReflectionClass(Address::class)
                 ),
             ],
-            $mock
+            $mock,
         ];
     }
 }

--- a/tests/Annotated/Unit/Locator/TokenizerEntityLocatorTest.php
+++ b/tests/Annotated/Unit/Locator/TokenizerEntityLocatorTest.php
@@ -35,7 +35,7 @@ final class TokenizerEntityLocatorTest extends TestCase
 
         $mock = $this->createMock(ClassesInterface::class);
         $mock->method('getClasses')->willReturn([
-            AnotherClass::class => new \ReflectionClass(AnotherClass::class)
+            AnotherClass::class => new \ReflectionClass(AnotherClass::class),
         ]);
         yield [[], $mock];
 
@@ -55,7 +55,7 @@ final class TokenizerEntityLocatorTest extends TestCase
                     new \ReflectionClass(WithTable::class)
                 ),
             ],
-            $mock
+            $mock,
         ];
     }
 }

--- a/tests/Annotated/Unit/Locator/TokenizerEntityLocatorTest.php
+++ b/tests/Annotated/Unit/Locator/TokenizerEntityLocatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Unit\Locator;
+
+use Cycle\Annotated\Annotation\Entity as Attribute;
+use Cycle\Annotated\Locator\Entity;
+use Cycle\Annotated\Locator\TokenizerEntityLocator;
+use Cycle\Annotated\Tests\Fixtures\Fixtures1\AnotherClass;
+use Cycle\Annotated\Tests\Fixtures\Fixtures1\Tag;
+use Cycle\Annotated\Tests\Fixtures\Fixtures1\Typecast\Typecaster;
+use Cycle\Annotated\Tests\Fixtures\Fixtures1\Typecast\UuidTypecaster;
+use Cycle\Annotated\Tests\Fixtures\Fixtures1\WithTable;
+use PHPUnit\Framework\TestCase;
+use Spiral\Tokenizer\ClassesInterface;
+
+final class TokenizerEntityLocatorTest extends TestCase
+{
+    /**
+     * @dataProvider classesDataProvider
+     */
+    public function testGetEntities(array $expected, ClassesInterface $classes): void
+    {
+        $locator = new TokenizerEntityLocator($classes);
+
+        $this->assertEquals($expected, $locator->getEntities());
+    }
+
+    public function classesDataProvider(): \Traversable
+    {
+        $mock = $this->createMock(ClassesInterface::class);
+        $mock->method('getClasses')->willReturn([]);
+        yield [[], $mock];
+
+        $mock = $this->createMock(ClassesInterface::class);
+        $mock->method('getClasses')->willReturn([
+            AnotherClass::class => new \ReflectionClass(AnotherClass::class)
+        ]);
+        yield [[], $mock];
+
+        $mock = $this->createMock(ClassesInterface::class);
+        $mock->method('getClasses')->willReturn([
+            Tag::class => new \ReflectionClass(Tag::class),
+            WithTable::class => new \ReflectionClass(WithTable::class),
+        ]);
+        yield [
+            [
+                new Entity(
+                    new Attribute(typecast: [Typecaster::class, UuidTypecaster::class, 'foo']),
+                    new \ReflectionClass(Tag::class)
+                ),
+                new Entity(
+                    new Attribute(),
+                    new \ReflectionClass(WithTable::class)
+                ),
+            ],
+            $mock
+        ];
+    }
+}


### PR DESCRIPTION
In the `Entities` and `Embeddings` generators, the logic for searching for classes with attributes is moved to separate locators. Now they only accept the locator interface and don't know anything about the implementation. This will allow these generators to be used with different implementations searching classes with attributes.