### PR TITLE
Add `readonlySchema` to the `Column` annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": ">=8.0",
         "cycle/orm": "^2.2.0",
         "cycle/schema-builder": "^2.3",
+        "cycle/database": "^2.5",
         "doctrine/annotations": "^1.14.3 || ^2.0.1",
         "spiral/attributes": "^2.8|^3.0",
         "spiral/tokenizer": "^2.8|^3.0",

--- a/src/Annotation/Column.php
+++ b/src/Annotation/Column.php
@@ -45,6 +45,7 @@ final class Column
      *        If you want to use another rule you should add in the `typecast` argument of the {@see Entity} attribute
      *        a relevant Typecast handler that supports the rule.
      * @param bool $castDefault
+     * @param bool $readonlySchema Set to true to disable schema synchronization for the assigned column.
      * @param mixed ...$attributes Other database specific attributes. Use named notation to define them.
      *        For example: #[Column('smallInt', unsigned: true, zerofill: true)]
      */
@@ -68,6 +69,7 @@ final class Column
         private mixed $default = null,
         private mixed $typecast = null,
         private bool $castDefault = false,
+        private bool $readonlySchema = false,
         mixed ...$attributes,
     ) {
         if ($default !== null) {
@@ -119,6 +121,11 @@ final class Column
     public function getTypecast(): mixed
     {
         return $this->typecast;
+    }
+
+    public function isReadonlySchema(): bool
+    {
+        return $this->readonlySchema;
     }
 
     /**

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -243,6 +243,10 @@ final class Configurator
             $field->getOptions()->set(\Cycle\Schema\Table\Column::OPT_CAST_DEFAULT, true);
         }
 
+        if ($column->isReadonlySchema()) {
+            $field->getAttributes()->set('readOnly', true);
+        }
+
         foreach ($column->getAttributes() as $k => $v) {
             $field->getAttributes()->set($k, $v);
         }

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -244,7 +244,7 @@ final class Configurator
         }
 
         if ($column->isReadonlySchema()) {
-            $field->getAttributes()->set('readOnly', true);
+            $field->getAttributes()->set('readonlySchema', true);
         }
 
         foreach ($column->getAttributes() as $k => $v) {

--- a/tests/Annotated/Fixtures/Fixtures1/Simple.php
+++ b/tests/Annotated/Fixtures/Fixtures1/Simple.php
@@ -66,4 +66,10 @@ class Simple implements LabelledInterface
      */
     #[MorphedHasMany(target: 'Label', outerKey: 'owner_id', morphKey: 'owner_role', indexCreate: false, collection: Collection\BaseCollection::class)] // phpcs:ignore
     protected $labels;
+
+    /**
+     * @Column(type="string", readonlySchema=true)
+     */
+    #[Column(type: 'string', readonlySchema: true)]
+    protected string $readOnlyColumn;
 }

--- a/tests/Annotated/Functional/Driver/Common/TableTest.php
+++ b/tests/Annotated/Functional/Driver/Common/TableTest.php
@@ -294,7 +294,7 @@ abstract class TableTest extends BaseTest
     /**
      * @dataProvider allReadersProvider
      */
-    public function testReadOnly(ReaderInterface $reader): void
+    public function testReadonlySchema(ReaderInterface $reader): void
     {
         $r = new Registry($this->dbal);
         (new Entities($this->locator, $reader))->run($r);
@@ -305,6 +305,6 @@ abstract class TableTest extends BaseTest
 
         $schema = $r->getTableSchema($r->getEntity('simple'));
 
-        $this->assertTrue($schema->column('read_only_column')->isReadOnly());
+        $this->assertTrue($schema->column('read_only_column')->isReadonlySchema());
     }
 }

--- a/tests/Annotated/Functional/Driver/Common/TableTest.php
+++ b/tests/Annotated/Functional/Driver/Common/TableTest.php
@@ -290,4 +290,21 @@ abstract class TableTest extends BaseTest
 
         $this->assertSame('with_table', $schema->getName());
     }
+
+    /**
+     * @dataProvider allReadersProvider
+     */
+    public function testReadOnly(ReaderInterface $reader): void
+    {
+        $r = new Registry($this->dbal);
+        (new Entities($this->locator, $reader))->run($r);
+        (new MergeColumns($reader))->run($r);
+        (new RenderTables())->run($r);
+
+        $this->assertTrue($r->hasTable($r->getEntity('simple')));
+
+        $schema = $r->getTableSchema($r->getEntity('simple'));
+
+        $this->assertTrue($schema->column('read_only_column')->isReadOnly());
+    }
 }

--- a/tests/Annotated/Unit/Attribute/ColumnTest.php
+++ b/tests/Annotated/Unit/Attribute/ColumnTest.php
@@ -19,6 +19,9 @@ class ColumnTest extends TestCase
     #[Column('string(32)', size: 128)]
     private $column3;
 
+    #[Column('string(32)', readonlySchema: true)]
+    private mixed $column4;
+
     public function testOneAttribute(): void
     {
         $attr = $this->getAttribute('column1');
@@ -38,6 +41,20 @@ class ColumnTest extends TestCase
         $attr = $this->getAttribute('column3');
 
         $this->assertSame(['size' => 128], $attr->getAttributes());
+    }
+
+    public function testDefaultReadOnly(): void
+    {
+        $attr = $this->getAttribute('column1');
+
+        $this->assertFalse($attr->isReadonlySchema());
+    }
+
+    public function testReadOnly(): void
+    {
+        $attr = $this->getAttribute('column4');
+
+        $this->assertTrue($attr->isReadonlySchema());
     }
 
     private function getAttribute(string $field): Column

--- a/tests/Annotated/Unit/Attribute/ColumnTest.php
+++ b/tests/Annotated/Unit/Attribute/ColumnTest.php
@@ -43,14 +43,14 @@ class ColumnTest extends TestCase
         $this->assertSame(['size' => 128], $attr->getAttributes());
     }
 
-    public function testDefaultReadOnly(): void
+    public function testDefaultReadonlySchema(): void
     {
         $attr = $this->getAttribute('column1');
 
         $this->assertFalse($attr->isReadonlySchema());
     }
 
-    public function testReadOnly(): void
+    public function testReadonlySchema(): void
     {
         $attr = $this->getAttribute('column4');
 


### PR DESCRIPTION
- [x] https://github.com/cycle/database/pull/116

## Feature

Added the ability to disable schema synchronization for the assigned column via **readonlySchema: true**:

```php
use App\Infrastructure\Persistence\CycleORMUserRepository;
use Cycle\Annotated\Annotation\Column;
use Cycle\Annotated\Annotation\Entity;

#[Entity(
    repository: CycleORMUserRepository::class
)]
class User
{
    public function __construct(
        #[Column(type: 'primary')]
        public int $id,
        #[Column(type: 'string(64)')]
        public string $username,
        #[Column(type: 'string', readonlySchema: true)]
        public string $email
    ) {
    }
}
```

Similar to the **readonlySchema** parameter in the **Entity** annotation:
https://github.com/cycle/annotated/blob/3.x/src/Annotation/Entity.php#L38