### PR TITLE
Removes requirement of doctrine/annotations 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.0",
         "cycle/orm": "^2.2.0",
         "cycle/schema-builder": "^2.4",
-        "doctrine/annotations": "^1.14.3 || ^2.0.1",
+        "doctrine/annotations": "^1.14.3",
         "spiral/attributes": "^2.8|^3.0",
         "spiral/tokenizer": "^2.8|^3.0",
         "doctrine/inflector": "^2.0"


### PR DESCRIPTION
This PR removes requirement of `doctrine/annotations` version `2.0.1`, because this version doesn't have already deprecated `AnnotationRegistry::registerLoader` which is required to use. Now it requires only `^1.14.3`, where this method works.