### PR TITLE
Support more types as value of `SingleTable` attribute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup DB services
         run: |
           cd tests
-          docker-compose up -d
+          docker compose up -d
           cd ..
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/src/Annotation/Inheritance/SingleTable.php
+++ b/src/Annotation/Inheritance/SingleTable.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Cycle\Annotated\Annotation\Inheritance;
 
+use BackedEnum;
 use Cycle\Annotated\Annotation\Inheritance;
 use Spiral\Attributes\NamedArgumentConstructor;
+use Stringable;
 
 /**
  * @Annotation
@@ -15,9 +17,14 @@ use Spiral\Attributes\NamedArgumentConstructor;
 #[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
 class SingleTable extends Inheritance
 {
+    protected ?string $value;
+
     public function __construct(
-        protected ?string $value = null
+        string|int|float|Stringable|BackedEnum|null $value = null
     ) {
+        $this->value = $value === null
+            ? null
+            : (string) ($value instanceof BackedEnum ? $value->value : $value);
         parent::__construct('single');
     }
 

--- a/src/Annotation/Inheritance/SingleTable.php
+++ b/src/Annotation/Inheritance/SingleTable.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Cycle\Annotated\Annotation\Inheritance;
 
-use BackedEnum;
 use Cycle\Annotated\Annotation\Inheritance;
 use Spiral\Attributes\NamedArgumentConstructor;
-use Stringable;
 
 /**
  * @Annotation
@@ -20,11 +18,11 @@ class SingleTable extends Inheritance
     protected ?string $value;
 
     public function __construct(
-        string|int|float|Stringable|BackedEnum|null $value = null
+        string|int|float|\Stringable|\BackedEnum|null $value = null
     ) {
         $this->value = $value === null
             ? null
-            : (string) ($value instanceof BackedEnum ? $value->value : $value);
+            : (string) ($value instanceof \BackedEnum ? $value->value : $value);
         parent::__construct('single');
     }
 

--- a/tests/Annotated/Unit/Attribute/SingleTable/IntegerEnum.php
+++ b/tests/Annotated/Unit/Attribute/SingleTable/IntegerEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Unit\Attribute\SingleTable;
+
+enum IntegerEnum: int
+{
+    case ONE = 1;
+    case TWO = 2;
+}

--- a/tests/Annotated/Unit/Attribute/SingleTable/SingleTableTest.php
+++ b/tests/Annotated/Unit/Attribute/SingleTable/SingleTableTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Unit\Attribute\SingleTable;
+
+use Cycle\Annotated\Annotation\Inheritance\SingleTable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SingleTableTest extends TestCase
+{
+    public static function dataBase(): iterable
+    {
+        yield [null, null];
+        yield ['test', 'test'];
+        yield ['42', 42];
+        yield ['36.6', 36.6];
+        yield ['test', new StringableObject('test')];
+        yield ['1', IntegerEnum::ONE];
+        yield ['a', StringEnum::A];
+    }
+
+    #[DataProvider('dataBase')]
+    public function testBase1(?string $expected, mixed $value): void
+    {
+        $attribute = new SingleTable($value);
+
+        $this->assertSame($expected, $attribute->getValue());
+    }
+}

--- a/tests/Annotated/Unit/Attribute/SingleTable/StringEnum.php
+++ b/tests/Annotated/Unit/Attribute/SingleTable/StringEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Unit\Attribute\SingleTable;
+
+enum StringEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+}

--- a/tests/Annotated/Unit/Attribute/SingleTable/StringableObject.php
+++ b/tests/Annotated/Unit/Attribute/SingleTable/StringableObject.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Unit\Attribute\SingleTable;
+
+use Stringable;
+
+final class StringableObject implements Stringable
+{
+    public function __construct(
+        private string $value,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       ACCEPT_EULA: "Y"
 
   mysql_latest:
-    image: mysql:latest
+    image: mysql:8
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     ports:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       ACCEPT_EULA: "Y"
 
   mysql_latest:
-    image: mysql:8
+    image: mysql:8.0
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     ports:


### PR DESCRIPTION
## 🔍 What was changed

Added support integer, float, `Stringable` and backed enumerations as value of `SingleTable` attribute.

## 🤔 Why?

For example, use backed enumeration as value.
