### PR TITLE
Metastorm: cover inner and outer keys in relations

### DIFF
--- a/resources/annotated.meta-storm.xml
+++ b/resources/annotated.meta-storm.xml
@@ -15,17 +15,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
     </definitions>
 </meta-storm>

--- a/resources/annotated.meta-storm.xml
+++ b/resources/annotated.meta-storm.xml
@@ -1,14 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <meta-storm xmlns="meta-storm">
     <definitions>
+        <!-- Embeddable Entity -->
         <classConstructor class="\Cycle\Annotated\Annotation\Embeddable" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
 
+        <!-- Foreign Key -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
+        </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\ForeignKey" argument="2">
+            <properties xpath="$argument[0]"/>
         </classConstructor>
     </definitions>
 </meta-storm>

--- a/resources/relations.meta-storm.xml
+++ b/resources/relations.meta-storm.xml
@@ -1,26 +1,92 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <meta-storm xmlns="meta-storm">
     <definitions>
+        <!-- Belongs To -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
+        <!-- Has Many -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
+        <!-- Has One -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
+        <!-- Refers To -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
+        <!-- Many To Many -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="0">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
@@ -29,22 +95,100 @@
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- target innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="2" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="2">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- target outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="3" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="3">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <!-- through innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="4" targetInArray="value">
+            <properties xpath="$argument[1]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="4">
+            <properties xpath="$argument[1]"/>
+        </classConstructor>
+        <!-- through outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="5" targetInArray="value">
+            <properties xpath="$argument[1]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="5">
+            <properties xpath="$argument[1]"/>
+        </classConstructor>
 
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsToMorphed" argument="1">
+        <!-- Belongs To Morphed -->
+        <!-- target: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="1">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\MorphedHasMany" argument="1">
+        <!-- Morphed Has Many -->
+        <!-- target: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="1">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\MorphedHasOne" argument="1">
+        <!-- Morphed Has One -->
+        <!-- target: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="1">
             <collection name="cycle/orm:entity-class" argument="0" />
             <collection name="cycle/orm:entity-role" argument="0" />
         </classConstructor>
+        <!-- innerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="1" targetInArray="value">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="1">
+            <properties xpath="$containingClass"/>
+        </classConstructor>
+        <!-- outerKey: -->
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="2" targetInArray="value">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
+        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="2">
+            <properties xpath="$argument[0]"/>
+        </classConstructor>
 
+        <!-- Embedded -->
+        <!-- target: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Embedded" argument="0">
             <collection name="cycle/orm:entity-embeddable-class" argument="0" />
         </classConstructor>

--- a/resources/relations.meta-storm.xml
+++ b/resources/relations.meta-storm.xml
@@ -9,17 +9,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\BelongsTo" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Has Many -->
@@ -30,17 +32,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasMany" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Has One -->
@@ -51,17 +55,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\HasOne" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Refers To -->
@@ -72,17 +78,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\RefersTo" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Many To Many -->
@@ -97,31 +105,35 @@
         </classConstructor>
         <!-- target innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="2" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="2">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- target outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="3" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="3">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- through innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="4" targetInArray="value">
-            <properties xpath="$argument[1]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="4">
-            <properties xpath="$argument[1]"/>
+            <properties xpath="$argument[1]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- through outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="5" targetInArray="value">
-            <properties xpath="$argument[1]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\ManyToMany" argument="5">
-            <properties xpath="$argument[1]"/>
+            <properties xpath="$argument[1]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Belongs To Morphed -->
@@ -132,17 +144,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Morphed Has Many -->
@@ -153,17 +167,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasMany" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Morphed Has One -->
@@ -174,17 +190,19 @@
         </classConstructor>
         <!-- innerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="1" targetInArray="value">
-            <properties xpath="$containingClass"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="1">
-            <properties xpath="$containingClass"/>
+            <properties xpath="$containingClass">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
         <!-- outerKey: -->
         <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="2" targetInArray="value">
-            <properties xpath="$argument[0]"/>
-        </classConstructor>
-        <classConstructor class="\Cycle\Annotated\Annotation\Relation\Morphed\MorphedHasOne" argument="2">
-            <properties xpath="$argument[0]"/>
+            <properties xpath="$argument[0]">
+                <filters>
+                    <hasAttribute class="\Cycle\Annotated\Annotation\Column"/>
+                </filters>
+            </properties>
         </classConstructor>
 
         <!-- Embedded -->

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2019-latest
-    restart: always
     ports:
       - "11433:1433"
     environment:
@@ -12,7 +11,6 @@ services:
 
   mysql_latest:
     image: mysql:8.0
-    restart: always
     command: --default-authentication-plugin=mysql_native_password
     ports:
       - "13306:3306"
@@ -23,7 +21,6 @@ services:
 
   postgres:
     image: postgres:12
-    restart: always
     ports:
       - "15432:5432"
     environment:


### PR DESCRIPTION
It doesn't filter non-column properties yet

![image](https://github.com/user-attachments/assets/6f8608fa-8998-4f3d-bd08-9faa72e350c0)

But now we can navigate to specified properties