### PR TITLE
Added the ability to specify typecasts in the Embeddable attribute

### DIFF
--- a/src/Annotation/Embeddable.php
+++ b/src/Annotation/Embeddable.php
@@ -20,7 +20,7 @@ class Embeddable
      * @param class-string|null $mapper Mapper class name. Defaults to {@see \Cycle\ORM\Mapper\Mapper}.
      * @param string $columnPrefix Custom prefix for embeddable entity columns.
      * @param Column[] $columns Embedded entity columns.
-     * @param non-empty-string|non-empty-string[]|null $typecast Typecasts for embeddable entity columns.
+     * @param non-empty-string|non-empty-string[]|null $typecast Typecast handlers for entity columns.
      */
     public function __construct(
         protected ?string $role = null,

--- a/src/Annotation/Embeddable.php
+++ b/src/Annotation/Embeddable.php
@@ -20,12 +20,14 @@ class Embeddable
      * @param class-string|null $mapper Mapper class name. Defaults to {@see \Cycle\ORM\Mapper\Mapper}.
      * @param string $columnPrefix Custom prefix for embeddable entity columns.
      * @param Column[] $columns Embedded entity columns.
+     * @param non-empty-string|non-empty-string[]|null $typecast Typecasts for embeddable entity columns.
      */
     public function __construct(
         protected ?string $role = null,
         protected ?string $mapper = null,
         protected string $columnPrefix = '',
         protected array $columns = [],
+        protected array|string|null $typecast = null,
     ) {}
 
     /**
@@ -55,5 +57,13 @@ class Embeddable
     public function getColumns(): array
     {
         return $this->columns;
+    }
+
+    /**
+     * @return non-empty-string|non-empty-string[]|null
+     */
+    public function getTypecast(): array|string|null
+    {
+        return $this->typecast;
     }
 }

--- a/src/Annotation/Entity.php
+++ b/src/Annotation/Entity.php
@@ -29,7 +29,7 @@ class Entity
      * @param non-empty-string|null $database Database name. Defaults to null (default database).
      * @param class-string<Source>|null $source Entity source class (internal).
      *        Defaults to {@see \Cycle\ORM\Select\Source}
-     * @param non-empty-string|non-empty-string[]|null $typecast Typecasts for entity columns.
+     * @param non-empty-string|non-empty-string[]|null $typecast Typecast handlers for entity columns.
      * @param class-string<Scope>|null $scope Class name of constraint to be applied to every entity query.
      * @param Column[] $columns Entity columns.
      * @param ForeignKey[] $foreignKeys Entity foreign keys.

--- a/src/Annotation/Entity.php
+++ b/src/Annotation/Entity.php
@@ -29,7 +29,7 @@ class Entity
      * @param non-empty-string|null $database Database name. Defaults to null (default database).
      * @param class-string<Source>|null $source Entity source class (internal).
      *        Defaults to {@see \Cycle\ORM\Select\Source}
-     * @param non-empty-string|non-empty-string[]|null $typecast
+     * @param non-empty-string|non-empty-string[]|null $typecast Typecasts for entity columns.
      * @param class-string<Scope>|null $scope Class name of constraint to be applied to every entity query.
      * @param Column[] $columns Entity columns.
      * @param ForeignKey[] $foreignKeys Entity foreign keys.

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -90,6 +90,7 @@ final class Configurator
 
         // representing classes
         $e->setMapper($this->resolveName($emb->getMapper(), $class));
+        $e->setTypecast($this->resolveTypecast($emb->getTypecast(), $class));
 
         return $e;
     }

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -90,7 +90,18 @@ final class Configurator
 
         // representing classes
         $e->setMapper($this->resolveName($emb->getMapper(), $class));
-        $e->setTypecast($this->resolveTypecast($emb->getTypecast(), $class));
+
+        $typecast = $emb->getTypecast();
+
+        if (\is_array($typecast)) {
+            /** @var non-empty-string[] $typecast */
+            $typecast = \array_map(fn(string $value): string => $this->resolveName($value, $class), $typecast);
+        } else {
+            /** @var non-empty-string|null $typecast */
+            $typecast = $this->resolveName($typecast, $class);
+        }
+
+        $e->setTypecast($typecast);
 
         return $e;
     }

--- a/tests/Annotated/Fixtures/Fixtures26/Address.php
+++ b/tests/Annotated/Fixtures/Fixtures26/Address.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Fixtures\Fixtures26;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Embeddable;
+
+/**
+ * @Embeddable(
+ *     role="address",
+ *     columnPrefix="address_",
+ *     typecast={"Cycle\Annotated\Tests\Fixtures\Fixtures26\CityTypecast"}
+ * )
+ */
+#[Embeddable(
+    role: 'address',
+    columnPrefix: 'address_',
+    typecast: [
+        CityTypecast::class,
+    ],
+)]
+class Address
+{
+    /** @Column(type="string", typecast="city") */
+    #[Column(type: 'string', typecast: 'city')]
+    protected City $city;
+
+    /** @Column(type="string") */
+    #[Column(type: 'string')]
+    protected $country;
+
+    /** @Column(type="string") */
+    #[Column(type: 'string')]
+    protected $address;
+
+    /** @Column(type="int") */
+    #[Column(type: 'integer')]
+    protected $zipcode;
+}

--- a/tests/Annotated/Fixtures/Fixtures26/City.php
+++ b/tests/Annotated/Fixtures/Fixtures26/City.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Fixtures\Fixtures26;
+
+final class City
+{
+    private string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+}

--- a/tests/Annotated/Fixtures/Fixtures26/CityTypecast.php
+++ b/tests/Annotated/Fixtures/Fixtures26/CityTypecast.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Fixtures\Fixtures26;
+
+use Cycle\ORM\Parser\CastableInterface;
+use Cycle\ORM\Parser\UncastableInterface;
+
+final class CityTypecast implements CastableInterface, UncastableInterface
+{
+    private array $rules = [];
+
+    public function cast(array $data): array
+    {
+        foreach (array_keys($this->rules) as $column) {
+            if (!isset($data[$column])) {
+                continue;
+            }
+
+            if (!\is_string($data[$column]) || $data[$column] === '') {
+                $data[$column] = null;
+
+                continue;
+            }
+
+            $data[$column] = City::fromString($data[$column]);
+        }
+
+        return $data;
+    }
+
+    public function uncast(array $data): array
+    {
+        foreach (array_keys($this->rules) as $column) {
+            if (!isset($data[$column])) {
+                continue;
+            }
+
+            $value = $data[$column];
+
+            if (!$value instanceof City) {
+                continue;
+            }
+
+            $data[$column] = (string)$value;
+        }
+
+        return $data;
+    }
+
+    public function setRules(array $rules): array
+    {
+        /** @var non-empty-string $rule */
+        foreach ($rules as $key => $rule) {
+            if ($rule !== 'city') {
+                continue;
+            }
+
+            unset($rules[$key]);
+
+            $this->rules[$key] = $rule;
+        }
+
+        return $rules;
+    }
+}

--- a/tests/Annotated/Fixtures/Fixtures26/User.php
+++ b/tests/Annotated/Fixtures/Fixtures26/User.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Annotated\Tests\Fixtures\Fixtures26;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\Annotated\Annotation\Relation\Embedded;
+
+/**
+ * @Entity()
+ */
+#[Entity]
+class User
+{
+    /** @Column(type="primary") */
+    #[Column(type: 'primary')]
+    protected $id;
+
+    /** @Embedded(target=Address::class) */
+    #[Embedded(target: Address::class)]
+    protected $address;
+}

--- a/tests/Annotated/Functional/Driver/Common/Relation/EmbeddedTestCase.php
+++ b/tests/Annotated/Functional/Driver/Common/Relation/EmbeddedTestCase.php
@@ -10,6 +10,7 @@ use Cycle\Annotated\Locator\TokenizerEmbeddingLocator;
 use Cycle\Annotated\Locator\TokenizerEntityLocator;
 use Cycle\Annotated\MergeColumns;
 use Cycle\Annotated\MergeIndexes;
+use Cycle\Annotated\Tests\Fixtures\Fixtures26\CityTypecast;
 use Cycle\Annotated\Tests\Functional\Driver\Common\BaseTestCase;
 use Cycle\ORM\Relation;
 use Cycle\ORM\Schema;
@@ -136,5 +137,33 @@ abstract class EmbeddedTestCase extends BaseTestCase
 
         $this->assertSame($address, $schema['user:address:address'][Schema::COLUMNS]);
         $this->assertSame($workAddress, $schema['user:address:workAddress'][Schema::COLUMNS]);
+    }
+
+    #[DataProvider('allReadersProvider')]
+    public function testEmbeddedTypecast(ReaderInterface $reader): void
+    {
+        $tokenizer = new Tokenizer(new TokenizerConfig([
+            'directories' => [__DIR__ . '/../../../../Fixtures/Fixtures26'],
+            'exclude' => [],
+        ]));
+
+        $locator = $tokenizer->classLocator();
+
+        $r = new Registry($this->dbal);
+
+        $schema = (new Compiler())->compile($r, [
+            new Embeddings(new TokenizerEmbeddingLocator($locator, $reader), $reader),
+            new Entities(new TokenizerEntityLocator($locator, $reader), $reader),
+            new ResetTables(),
+            new MergeColumns($reader),
+            new GenerateRelations(),
+            new RenderTables(),
+            new RenderRelations(),
+            new MergeIndexes($reader),
+            new SyncTables(),
+            new GenerateTypecast(),
+        ]);
+
+        $this->assertSame(CityTypecast::class, $schema['user:address:address'][Schema::TYPECAST_HANDLER][0]);
     }
 }


### PR DESCRIPTION
<!-- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

## 🔍 What was changed

Added the ability to specify typecasts for the Embeddable attribute.

I tested locally on a real project by making edits to the code in the package in vendor directory also.

Example:

```php
#[Embeddable(
    typecast: [
        SomeTypecast::class,
        \Cycle\ORM\Parser\Typecast::class,
    ]
)]
class SomeEmbeddable
{
    #[Column(type: 'string', typecast: 'some_type')]
    public Some $someField;
}
```

```php
#[Entity]
class SomeEntity
{
    #[Embedded(target: SomeEmbeddable::class)]
    public SomeEmbeddable $someEmbeddable;
}
```

> [!NOTE]
> Based on [the discussion](https://github.com/orgs/cycle/discussions/522)

## 🤔 Why?

Embeddable schemas have the ability to specify typecasts, however, this ability is not available when using attributes.

Failed test [here](https://github.com/cycle/annotated/pull/115).

## 📝 Checklist

<!--- add/delete as needed --->

- How was this tested:
  - [x] Tested manually
  - [x] Functional tests added
