### PR TITLE
Allow BackedEnum as default value in Column definition

### DIFF
--- a/src/Annotation/Column.php
+++ b/src/Annotation/Column.php
@@ -72,6 +72,7 @@ class Column
     ) {
         if ($default !== null) {
             $this->hasDefault = true;
+            $default instanceof \BackedEnum and $this->default = $default->value;
         }
         $this->setAttributes($attributes);
     }

--- a/tests/Annotated/Unit/Attribute/ColumnTest.php
+++ b/tests/Annotated/Unit/Attribute/ColumnTest.php
@@ -53,6 +53,13 @@ class ColumnTest extends TestCase
     #[Column(type: 'string', length: 255, charset: 'ascii', collation: 'ascii_bin')]
     private string $column9;
 
+    #[Column(
+        type: 'enum',
+        default: StringEnum::A,
+        values: StringEnum::class,
+    )]
+    private StringEnum $column10 = StringEnum::A;
+
     public function testOneAttribute(): void
     {
         $column = $this->getColumn('column1');
@@ -116,6 +123,15 @@ class ColumnTest extends TestCase
     public function testEnumTypeArrayBackedEnum(): void
     {
         $column = $this->getColumn('column8');
+
+        $this->assertSame('enum(a,b)', $column->getType());
+        $this->assertSame('a', $column->getDefault());
+        $this->assertArrayNotHasKey('values', $column->getAttributes());
+    }
+
+    public function testEnumTypeBackedEnumAsDefault(): void
+    {
+        $column = $this->getColumn('column10');
 
         $this->assertSame('enum(a,b)', $column->getType());
         $this->assertSame('a', $column->getDefault());


### PR DESCRIPTION
## 🔍 What was changed

This pull request adds support for using backed enum values as default values in columns annotated with the `Column` attribute. It also introduces a corresponding test to ensure that the default value is correctly set to the enum's backing value.

**Enhancements to enum default value handling:**

* Updated the `Column` annotation's constructor to set the default value to the enum's backing value when a backed enum is provided as the default. (`src/Annotation/Column.php`, [src/Annotation/Column.phpR75](diffhunk://#diff-665300e339d2914dfbf59c223f4c5c360f1dd12525b771f570d8fd290f12b9ebR75))

**Testing improvements:**

* Added a new property `column10` to `ColumnTest` that uses a backed enum as the default value, and introduced a test method to verify the correct default handling and type. (`tests/Annotated/Unit/Attribute/ColumnTest.php`, [[1]](diffhunk://#diff-6009cf324b11a0b20f1c758146a757e498abed7798424a826cc480e77c8851b7R56-R62) [[2]](diffhunk://#diff-6009cf324b11a0b20f1c758146a757e498abed7798424a826cc480e77c8851b7R132-R140)

## 📝 Checklist

<!--- add/delete as needed --->

- Closes #120 
- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added
